### PR TITLE
バッジ未取得時に画像をグレースケールにする(IEのぞく)

### DIFF
--- a/html/user-badge.html
+++ b/html/user-badge.html
@@ -1,3 +1,13 @@
+<style>
+.no-badge-icon {
+  opacity: .56;
+  -webkit-filter: grayscale(100%);
+  -moz-filter: grayscale(100%);
+  -o-filter: grayscale(100%);
+  -ms-filter: grayscale(100%);
+  filter: grayscale(100%);
+}
+</style>
 <div class="md-grid">
   <div class="mdl-cell mdl-cell--8-col-desktop mdl-cell--2-offset-desktop mdl-cell--12-col">
     <div class="mdl-grid">

--- a/util/qa-ysb-html-builder.php
+++ b/util/qa-ysb-html-builder.php
@@ -9,7 +9,7 @@ class qa_ysb_html_builder {
     public static function output_user_badge($badges)
     {
         $imgurl = qa_opt('site_url').self::IMAGE_BASE.'badge_';
-        $imgclass = 'mdl-typography--display-1-color-contrast';
+        $imgclass = 'no-badge-icon';
         $txtclass = 'mdl-typography--body-1';
         $txtclass2 = 'mdl-typography--body-1-color-contrast mdl-color-text--grey';
         $headclass = 'mdl-typography--display-1-color-contrast';


### PR DESCRIPTION
IEには対応できませんが、バッジ取得時のバッジアイコンをグレーにして分かりやすくしました。
CSSは分量が少ないのでインラインにしています。
https://github.com/yshiga/bee-qa/issues/1191 対応