### PR TITLE
1259 良い回答のバッジが付与されない

### DIFF
--- a/qa-ysb-badge-master-data.php
+++ b/qa-ysb-badge-master-data.php
@@ -9,7 +9,7 @@ return array(
     array(
         'badgeid' => 102,
         'name' => 'good_answer',
-        'event' => 'q_vote_up'
+        'event' => 'a_vote_up'
     ),
     array(
         'badgeid' => 103,


### PR DESCRIPTION
- badge_master データ修正
  - 良い回答の対象イベントが `q_vote_up` だったので`a_vote_up`に修正